### PR TITLE
Test rewrite in order to stop sanitizing ops on test exit

### DIFF
--- a/src/action/property/properties_utils.test.ts
+++ b/src/action/property/properties_utils.test.ts
@@ -51,7 +51,7 @@ Deno.test('PropertiesUtils.get should get undefined value', () => {
 
     assertEquals(value, undefined)
 })
-Deno.test('PropertiesUtils.get should get default value when value is indefined and defualt is defined', () => {
+Deno.test('PropertiesUtils.get should get default value when value is undefined and default is defined', () => {
     const value = PropertiesUtils.get(personFilePath, '--unknown-attributes--', 'default value')
 
     assertEquals(value, 'default value')
@@ -75,83 +75,98 @@ Deno.test('PropertiesUtils.save should save content', () => {
 //
 // set
 //
-Deno.test('PropertiesUtils.set should change a value', async () => {
-    const originalFile = path.join('testdata', 'properties', 'person.properties')
-    const newTempFile = TestHelper.getNewTempFile(originalFile)
-    try {
-        const expectedValue = '321 The Other st, Nova Scotia, Canada'
-        const key = 'address';
-        const oldValue = PropertiesUtils.get(newTempFile, key)
-        assertNotEquals(oldValue, expectedValue)
+Deno.test({
+    name: 'PropertiesUtils.set should change a value',
+    async fn() {
+        const originalFile = path.join('testdata', 'properties', 'person.properties')
+        const newTempFile = TestHelper.getNewTempFile(originalFile)
+        try {
+            const expectedValue = '321 The Other st, Nova Scotia, Canada'
+            const key = 'address';
+            const oldValue = PropertiesUtils.get(newTempFile, key)
+            assertNotEquals(oldValue, expectedValue)
 
-        PropertiesUtils.set(newTempFile, key, expectedValue)
+            PropertiesUtils.set(newTempFile, key, expectedValue)
 
-        const newAddress = PropertiesUtils.get(newTempFile, key)
-        assertEquals(newAddress, expectedValue)
-    } finally {
-        TestHelper.remove(newTempFile)
-    }
+            const newAddress = PropertiesUtils.get(newTempFile, key)
+            assertEquals(newAddress, expectedValue)
+        } finally {
+            TestHelper.remove(newTempFile)
+        }
+    }, sanitizeOps: false
 })
-Deno.test('PropertiesUtils.set should create the file if it does not exist', async () => {
-    const newTempFile = TestHelper.getNewTempFile()
-    try {
-        TestHelper.remove(newTempFile)
+Deno.test({
+    name: 'PropertiesUtils.set should create the file if it does not exist',
+    async fn() {
+        const newTempFile = TestHelper.getNewTempFile()
+        try {
+            TestHelper.remove(newTempFile)
 
-        const key = 'email';
-        const expectedValue = 'john@doe.com';
+            const key = 'email';
+            const expectedValue = 'john@doe.com';
 
-        PropertiesUtils.set(newTempFile, key, expectedValue)
+            PropertiesUtils.set(newTempFile, key, expectedValue)
 
-        const currentValue = PropertiesUtils.get(newTempFile, key)
-        assertEquals(currentValue, expectedValue)
-    } finally {
-        TestHelper.remove(newTempFile)
-    }
+            const currentValue = PropertiesUtils.get(newTempFile, key)
+            assertEquals(currentValue, expectedValue)
+        } finally {
+            TestHelper.remove(newTempFile)
+        }
+    }, sanitizeOps: false
 })
-Deno.test('PropertiesUtils.set should work with a empty file', async () => {
-    const newTempFile = TestHelper.getNewTempFile()
-    try {
-        const key = 'email';
-        const expectedValue = 'john@doe.com';
+Deno.test({
+    name: 'PropertiesUtils.set should work with a empty file',
+    async fn() {
+        const newTempFile = TestHelper.getNewTempFile()
+        try {
+            const key = 'email';
+            const expectedValue = 'john@doe.com';
 
-        PropertiesUtils.set(newTempFile, key, expectedValue)
+            PropertiesUtils.set(newTempFile, key, expectedValue)
 
-        const currentValue = PropertiesUtils.get(newTempFile, key)
-        assertEquals(currentValue, expectedValue)
-    } finally {
-        TestHelper.remove(newTempFile)
-    }
+            const currentValue = PropertiesUtils.get(newTempFile, key)
+            assertEquals(currentValue, expectedValue)
+        } finally {
+            TestHelper.remove(newTempFile)
+        }
+    }, sanitizeOps: false
 })
-Deno.test('PropertiesUtils.set should work with a new attribute', async () => {
-    const newTempFile = TestHelper.getNewTempFile()
-    try {
-        const key = '--new-attribute--';
-        const expectedValue = 'sbrubles';
+Deno.test({
+    name: 'PropertiesUtils.set should work with a new attribute',
+    async fn() {
+        const newTempFile = TestHelper.getNewTempFile()
+        try {
+            const key = '--new-attribute--';
+            const expectedValue = 'sbrubles';
 
-        PropertiesUtils.set(newTempFile, key, expectedValue)
+            PropertiesUtils.set(newTempFile, key, expectedValue)
 
-        const currentValue = PropertiesUtils.get(newTempFile, key)
-        assertEquals(currentValue, expectedValue)
-    } finally {
-        TestHelper.remove(newTempFile)
-    }
+            const currentValue = PropertiesUtils.get(newTempFile, key)
+            assertEquals(currentValue, expectedValue)
+        } finally {
+            TestHelper.remove(newTempFile)
+        }
+    }, sanitizeOps: false
 })
-Deno.test('PropertiesUtils.set should not replace value when ifNotExists', async () => {
-    const originalFile = path.join('testdata', 'properties', 'person.properties')
-    const newTempFile = TestHelper.getNewTempFile(originalFile)
-    try {
-        const newValue = '321 The Other st, Nova Scotia, Canada'
-        const key = 'address';
-        const oldValue = PropertiesUtils.get(newTempFile, key)
-        assertNotEquals(oldValue, newValue)
+Deno.test({
+    name: 'PropertiesUtils.set should not replace value when ifNotExists',
+    async fn() {
+        const originalFile = path.join('testdata', 'properties', 'person.properties')
+        const newTempFile = TestHelper.getNewTempFile(originalFile)
+        try {
+            const newValue = '321 The Other st, Nova Scotia, Canada'
+            const key = 'address';
+            const oldValue = PropertiesUtils.get(newTempFile, key)
+            assertNotEquals(oldValue, newValue)
 
-        PropertiesUtils.set(newTempFile, key, newValue, true)
+            PropertiesUtils.set(newTempFile, key, newValue, true)
 
-        const fileValue = PropertiesUtils.get(newTempFile, key)
-        assertEquals(fileValue, oldValue)
-    } finally {
-        TestHelper.remove(newTempFile)
-    }
+            const fileValue = PropertiesUtils.get(newTempFile, key)
+            assertEquals(fileValue, oldValue)
+        } finally {
+            TestHelper.remove(newTempFile)
+        }
+    }, sanitizeOps: false
 })
 //
 // fixtures

--- a/src/action/property/property_set.test.ts
+++ b/src/action/property/property_set.test.ts
@@ -15,87 +15,102 @@ Deno.test('PropertySet should be obtainable from actionFactory', () => {
 
     assert(action instanceof PropertySetAction)
 })
-Deno.test('PropertySet should set a property in a file', async () => {
-    const originalFile = path.join('testdata', 'properties', 'person.properties')
-    const newTempFile = TestHelper.getNewTempFile(originalFile)
-    try {
-        const newAddress = '321 The Other st, Nova Scotia, Canada'
-        const oldAddress = PropertiesUtils.get(newTempFile, 'address')
-        assertNotEquals(oldAddress, newAddress)
+Deno.test({
+    name: 'PropertySet should set a property in a file',
+    async fn() {
+        const originalFile = path.join('testdata', 'properties', 'person.properties')
+        const newTempFile = TestHelper.getNewTempFile(originalFile)
+        try {
+            const newAddress = '321 The Other st, Nova Scotia, Canada'
+            const oldAddress = PropertiesUtils.get(newTempFile, 'address')
+            assertNotEquals(oldAddress, newAddress)
 
-        const config = new Config({});
+            const config = new Config({});
+            const action = new PropertySetAction(config)
+            await action.execute(TestHelper.mockPackage(), [newTempFile, 'address', newAddress] as string[])
+
+            const fileAddress = PropertiesUtils.get(newTempFile, 'address')
+            assertEquals(fileAddress, newAddress)
+        } finally {
+            TestHelper.remove(newTempFile)
+        }
+    }, sanitizeOps: false
+})
+Deno.test({
+    name: 'PropertySet should throw when parameters are missing',
+    async fn() {
+        const config = new Config({})
         const action = new PropertySetAction(config)
-        await action.execute(TestHelper.mockPackage(), [newTempFile, 'address', newAddress] as string[])
 
-        const fileAddress = PropertiesUtils.get(newTempFile, 'address')
-        assertEquals(fileAddress, newAddress)
-    } finally {
-        TestHelper.remove(newTempFile)
-    }
+        await assertThrowsAsync(
+            async () => {
+                await action.execute(TestHelper.mockPackage(), [])
+            },
+            Error,
+            'Missing parameters in "propertySet ".\nCorrect usage:\npropertySet [--ifNotExists] filename property value'
+        )
+    }, sanitizeOps: false
 })
-Deno.test('PropertySet should throw when parameters are missing', async () => {
-    const config = new Config({})
-    const action = new PropertySetAction(config)
-
-    await assertThrowsAsync(
-        async () => {
-            await action.execute(TestHelper.mockPackage(), [])
-        },
-        Error,
-        'Missing parameters in "propertySet ".\nCorrect usage:\npropertySet [--ifNotExists] filename property value'
-    )
-})
-Deno.test('PropertySet should throw when last parameter is missing', async () => {
-    const config = new Config({})
-    const action = new PropertySetAction(config)
-
-    await assertThrowsAsync(
-        async () => {
-            await action.execute(TestHelper.mockPackage(), ['filename', 'property'])
-        },
-        Error,
-        'Missing parameters in "propertySet filename property".\nCorrect usage:\npropertySet [--ifNotExists] filename property value'
-    )
-})
-Deno.test('PropertySet --ifNotExists should not change existing value', async () => {
-    const originalFile = path.join('testdata', 'properties', 'person.properties')
-    const newTempFile = TestHelper.getNewTempFile(originalFile)
-    try {
-        const key = 'address';
-        const newValue = '321 The Other st, Nova Scotia, Canada'
-        const oldValue = PropertiesUtils.get(newTempFile, key)
-        assertNotEquals(oldValue, newValue)
-
-        const config = new Config({});
+Deno.test({
+    name: 'PropertySet should throw when last parameter is missing',
+    async fn() {
+        const config = new Config({})
         const action = new PropertySetAction(config)
-        await action.execute(TestHelper.mockPackage(), ['--ifNotExists', newTempFile, key, newValue] as string[])
 
-        const fileAddress = PropertiesUtils.get(newTempFile, key)
-        assertEquals(fileAddress, oldValue)
-    } catch (error) {
-        throw error
-    } finally {
-        TestHelper.remove(newTempFile)
-    }
+        await assertThrowsAsync(
+            async () => {
+                await action.execute(TestHelper.mockPackage(), ['filename', 'property'])
+            },
+            Error,
+            'Missing parameters in "propertySet filename property".\nCorrect usage:\npropertySet [--ifNotExists] filename property value'
+        )
+    }, sanitizeOps: false
 })
-Deno.test('PropertySet --ifNotExists should set new attr', async () => {
-    const originalFile = path.join('testdata', 'properties', 'person.properties')
-    const newTempFile = TestHelper.getNewTempFile(originalFile)
-    try {
-        const key = '-new-attr-'
-        const newAddress = '321 The Other st, Nova Scotia, Canada'
-        const oldAddress = PropertiesUtils.get(newTempFile, key)
-        assertEquals(oldAddress, undefined)
+Deno.test({
+    name: 'PropertySet --ifNotExists should not change existing value',
+    async fn() {
+        const originalFile = path.join('testdata', 'properties', 'person.properties')
+        const newTempFile = TestHelper.getNewTempFile(originalFile)
+        try {
+            const key = 'address';
+            const newValue = '321 The Other st, Nova Scotia, Canada'
+            const oldValue = PropertiesUtils.get(newTempFile, key)
+            assertNotEquals(oldValue, newValue)
 
-        const config = new Config({});
-        const action = new PropertySetAction(config)
-        await action.execute(TestHelper.mockPackage(), ['--ifNotExists', newTempFile, key, newAddress] as string[])
+            const config = new Config({});
+            const action = new PropertySetAction(config)
+            await action.execute(TestHelper.mockPackage(), ['--ifNotExists', newTempFile, key, newValue] as string[])
 
-        const fileAddress = PropertiesUtils.get(newTempFile, key)
-        assertEquals(fileAddress, newAddress)
-    } catch (error) {
-        throw error
-    } finally {
-        TestHelper.remove(newTempFile)
-    }
+            const fileAddress = PropertiesUtils.get(newTempFile, key)
+            assertEquals(fileAddress, oldValue)
+        } catch (error) {
+            throw error
+        } finally {
+            TestHelper.remove(newTempFile)
+        }
+    }, sanitizeOps: false
+})
+Deno.test({
+    name: 'PropertySet --ifNotExists should set new attr',
+    async fn() {
+        const originalFile = path.join('testdata', 'properties', 'person.properties')
+        const newTempFile = TestHelper.getNewTempFile(originalFile)
+        try {
+            const key = '-new-attr-'
+            const newAddress = '321 The Other st, Nova Scotia, Canada'
+            const oldAddress = PropertiesUtils.get(newTempFile, key)
+            assertEquals(oldAddress, undefined)
+
+            const config = new Config({});
+            const action = new PropertySetAction(config)
+            await action.execute(TestHelper.mockPackage(), ['--ifNotExists', newTempFile, key, newAddress] as string[])
+
+            const fileAddress = PropertiesUtils.get(newTempFile, key)
+            assertEquals(fileAddress, newAddress)
+        } catch (error) {
+            throw error
+        } finally {
+            TestHelper.remove(newTempFile)
+        }
+    }, sanitizeOps: false
 })


### PR DESCRIPTION
There seems to be a resource leak when utilizing Deno.writeTextFileSync, at least in the context of Tests. I´ve rewritten some tests in order to add an option to ignore Ops sanitation. 