### PR TITLE
Get rid of unnamed packages. Closes issue #157

### DIFF
--- a/src/lib/package/package_manager.test.ts
+++ b/src/lib/package/package_manager.test.ts
@@ -50,6 +50,26 @@ Deno.test('Managers should resolve packages with a transitive dependency', async
     assertEquals(packageNames, ['transitive dependency', 'dependency with transitive', 'package with a transitive dependency',])
 })
 
+Deno.test('Managers should not crash with empty package', async () => {
+    // Given
+    const config = await getConfigWithMockRepo()
+    const manager = new PackageManager(config)
+    // When
+    const resolvedPackages = manager.resolvePackages(['package without dependencies', '', ' ', 'package with a transitive dependency'])
+    // Then
+    let packageNames = resolvedPackages?.map(it => it.name)
+    assertEquals(packageNames, ['package without dependencies', 'transitive dependency', 'dependency with transitive', 'package with a transitive dependency'])
+})
+
+Deno.test('Managers should ignore empty package', async () => {
+    // Given
+    let packageNames = ['package without dependencies', '', ' ', 'package with a transitive dependency']
+    // When
+    PackageManager.removeExtension(packageNames)
+    // Then
+    assertEquals(packageNames, ['package without dependencies', 'package with a transitive dependency'])
+})
+
 async function getConfigWithMockRepo(): Promise<Config> {
     const config = TestHelper.getConfig();
     const repoMock = new MockRepository('mockRepo1', [

--- a/src/lib/package/package_manager.ts
+++ b/src/lib/package/package_manager.ts
@@ -31,6 +31,9 @@ export default class PackageManager {
         let names: Set<string> = new Set(); // Solving circular references - Issue #11
         let error: boolean = false;
         for (const pkgName of pkgNames) {
+            if (!pkgName || !pkgName.trim()) {
+                continue
+            }
             let repo = (installedOnly ? this.config.repositoryManager.repositoryInstalled : this.config.repositoryManager.repository);
             let myError: boolean = this.resolveInRepo(repo, pkgs, names, pkgName, showLog);
             error = error || myError;
@@ -62,16 +65,24 @@ export default class PackageManager {
     }
 
     static removeExtension(pkgNames: string[]) {
-        log.debug(`removeExtension <- ${pkgNames}`)
+        log.debug(`removeExtension <- ${pkgNames}`);
 
-        for (let idx in pkgNames) {
-            pkgNames[idx] = pkgNames[idx]
-                .replace(/\.levain\.yaml$/, "")
-                .replace(/\.levain\.yml$/, "")
-                .replace(/\.levain$/, "")
-        }
+        let filteredPkgNames = pkgNames
+            .map(pkgName => {
+                if (!pkgName || !pkgName.trim()) {
+                    log.warning(`Ignoring package with null name, check your configuration file.`)
+                    return "";
+                } else {
+                    return pkgName
+                        .replace(/\.levain\.yaml$/, "")
+                        .replace(/\.levain\.yml$/, "")
+                        .replace(/\.levain$/, "");
+                }})
+            .filter(pkg => pkg !== "");
 
-        log.debug(`removeExtension -> ${pkgNames}`)
+        pkgNames.splice(0, pkgNames.length, ...filteredPkgNames);
+
+        log.debug(`removeExtension -> ${pkgNames}`);
     }
 
     package(pkgName: string): Package | undefined {


### PR DESCRIPTION
Closes issue #157 
```
Managers should not crash with empty package ...
------- output -------
WARNING RepositoryManager.repository(mockRepo1) - TEST ONLY!
WARNING Ignoring package with null name, check your configuration file.
WARNING Ignoring package with null name, check your configuration file.
INFO ==================================
# Resolve package without dependencies,package with a transitive dependency -> Done
----- output end -----
Managers should not crash with empty package ... ok (0ms)
Managers should ignore empty package ...
------- output -------
WARNING Ignoring package with null name, check your configuration file.
WARNING Ignoring package with null name, check your configuration file.
----- output end -----
Managers should ignore empty package ... ok (0ms)
```